### PR TITLE
Enable single writer, multiple reader support on HDF5 files

### DIFF
--- a/filewriter.py
+++ b/filewriter.py
@@ -219,6 +219,9 @@ class HDF5Writer(FileWriterBase):
         self._counter = 0
         self._counter_max = chunks
         self._started = True
+
+        # Enable concurrent access to the file
+        self._interface.swmr_mode = True
         
     def write(self, time_tag, data):
         """
@@ -257,9 +260,11 @@ class HDF5Writer(FileWriterBase):
             # Write
             ## Timestamps
             self._time[self._counter:self._counter+size] = time_tags[range_start:range_start+size]
+            self._time.flush()
             ## Data
             for i in range(data.shape[-1]):
                 self._pols[i][self._counter:self._counter+size,:] = data[range_start:range_start+size,0,:,i]
+                self._pols[i].flush()
             # Update the counter
             self._counter += size
         except ValueError:

--- a/filewriter.py
+++ b/filewriter.py
@@ -210,7 +210,7 @@ class HDF5Writer(FileWriterBase):
         
         # Create and fill
         self._interface = create_hdf5(self.filename, beam)
-        set_frequencies(self._interface, freq)
+        self._freq = set_frequencies(self._interface, freq)
         self._time = set_time(self._interface, navg / CHAN_BW, chunks)
         self._time_step = navg * int(round(FS/CHAN_BW))
         self._start_time_tag = LWATime(self.start_time, format='datetime', scale='utc').tuple
@@ -222,6 +222,7 @@ class HDF5Writer(FileWriterBase):
 
         # Enable concurrent access to the file
         self._interface.swmr_mode = True
+        self._freq.flush()
         
     def write(self, time_tag, data):
         """

--- a/lwahdf.py
+++ b/lwahdf.py
@@ -82,7 +82,7 @@ def create_hdf5(filename, beam, overwrite=False):
     return f
 
 
-def set_frequencies(f, frequency):
+def set_frequencies(f, frequency, swmr=False):
     """
     Define the frequency setup.
     """
@@ -95,9 +95,11 @@ def set_frequencies(f, frequency):
     tun = obs.get('Tuning1', None)
     tun['freq'] = frequency.astype('<f8')
     tun['freq'].attrs['Units'] = 'Hz'
+    if swmr:
+        tun['freq'].swmr_mode = True
 
 
-def set_time(f, tint, count, format='unix', scale='utc'):
+def set_time(f, tint, count, format='unix', scale='utc', swmr=False):
     """
     Set the integration time in seconds and create a data set to hold the time
     stamps.  Return the HDF5 data set.
@@ -111,10 +113,12 @@ def set_time(f, tint, count, format='unix', scale='utc'):
                                                                   "formats": ["<i8", "<f8"]}))
     tim.attrs['format'] = 'unix'
     tim.attrs['scale'] = 'utc'
+    if swmr:
+        tim.swmr_mode = True
     return tim
 
 
-def set_polarization_products(f, pols, count):
+def set_polarization_products(f, pols, count, swmr=False):
     """
     Set the polarization products and create a data set for each.  Returns a
     dictionary of data sets keyed by the product name and its numeric index in
@@ -141,6 +145,8 @@ def set_polarization_products(f, pols, count):
         d = tun.create_dataset(p, (count, nchan), '<f4', chunks=(chunk_size, nchan))
         d.attrs['axis0'] = 'time'
         d.attrs['axis1'] = 'frequency'
+        if swmr:
+            d.swmr_mode = True
         data_products[i] = d
         data_products[p] = d
     return data_products

--- a/lwahdf.py
+++ b/lwahdf.py
@@ -95,6 +95,7 @@ def set_frequencies(f, frequency):
     tun = obs.get('Tuning1', None)
     tun['freq'] = frequency.astype('<f8')
     tun['freq'].attrs['Units'] = 'Hz'
+    return tun['freq']
 
 
 def set_time(f, tint, count, format='unix', scale='utc'):

--- a/lwahdf.py
+++ b/lwahdf.py
@@ -27,7 +27,7 @@ def create_hdf5(filename, beam, overwrite=False):
             os.unlink(filename)
             
     # Open the file
-    f = h5py.File(filename, mode='w')
+    f = h5py.File(filename, mode='w', libver='latest')
     
     # Top level attributes
     ## Observer and Project Info.

--- a/lwahdf.py
+++ b/lwahdf.py
@@ -82,7 +82,7 @@ def create_hdf5(filename, beam, overwrite=False):
     return f
 
 
-def set_frequencies(f, frequency, swmr=False):
+def set_frequencies(f, frequency):
     """
     Define the frequency setup.
     """
@@ -95,11 +95,9 @@ def set_frequencies(f, frequency, swmr=False):
     tun = obs.get('Tuning1', None)
     tun['freq'] = frequency.astype('<f8')
     tun['freq'].attrs['Units'] = 'Hz'
-    if swmr:
-        tun['freq'].swmr_mode = True
 
 
-def set_time(f, tint, count, format='unix', scale='utc', swmr=False):
+def set_time(f, tint, count, format='unix', scale='utc'):
     """
     Set the integration time in seconds and create a data set to hold the time
     stamps.  Return the HDF5 data set.
@@ -113,12 +111,10 @@ def set_time(f, tint, count, format='unix', scale='utc', swmr=False):
                                                                   "formats": ["<i8", "<f8"]}))
     tim.attrs['format'] = 'unix'
     tim.attrs['scale'] = 'utc'
-    if swmr:
-        tim.swmr_mode = True
     return tim
 
 
-def set_polarization_products(f, pols, count, swmr=False):
+def set_polarization_products(f, pols, count):
     """
     Set the polarization products and create a data set for each.  Returns a
     dictionary of data sets keyed by the product name and its numeric index in
@@ -145,8 +141,6 @@ def set_polarization_products(f, pols, count, swmr=False):
         d = tun.create_dataset(p, (count, nchan), '<f4', chunks=(chunk_size, nchan))
         d.attrs['axis0'] = 'time'
         d.attrs['axis1'] = 'frequency'
-        if swmr:
-            d.swmr_mode = True
         data_products[i] = d
         data_products[p] = d
     return data_products


### PR DESCRIPTION
This PR enables HDF5 files to be read while they are being written via the single writer, multiple reader access mode.  Changes to the file are flushed to disk every 10 s.