### PR TITLE
does not assume one observation per session

### DIFF
--- a/ovro_data_recorder/lwahdf.py
+++ b/ovro_data_recorder/lwahdf.py
@@ -55,8 +55,9 @@ def create_hdf5(filename, beam, overwrite=False):
         if dd[kk]['SESSION']['SESSION_DRX_BEAM'] == str(beam):
             for kkobs in dd[kk]['OBSERVATIONS'].keys():
                 mjd_start = int(dd[kk]['OBSERVATIONS'][kkobs]['OBS_START_MJD'])+int(dd[kk]['OBSERVATIONS'][kkobs]['OBS_START_MPM'])/(1e3*24*3600)
-                mjd_stop = mjd_start + int(dd[kk]['OBSERVATIONS'][kkobs]['OBS_DUR'])/(1e3*24*3600)
-                if mjd_now >= mjd_start and mjd_now < mjd_stop:
+                mjd_delta = int(dd[kk]['OBSERVATIONS'][kkobs]['OBS_DUR'])/(1e3*24*3600)
+                mjd_stop = mjd_start + mjd_delta
+                if mjd_now + mjd_delta/2 >= mjd_start and mjd_now + mjd_delta/2 < mjd_stop:  # align at midpoint of observation
                     sessionname = kk
                     session = dd[sessionname]['SESSION']
                     observation = dd[sessionname]['OBSERVATIONS'][kkobs]

--- a/ovro_data_recorder/lwahdf.py
+++ b/ovro_data_recorder/lwahdf.py
@@ -52,13 +52,14 @@ def create_hdf5(filename, beam, overwrite=False):
     observation = {}
     for kk, vv in dd.items():
         if dd[kk]['SESSION']['SESSION_DRX_BEAM'] == str(beam):
-            mjd_start = int(dd[kk]['OBSERVATIONS']['OBSERVATION_1']['OBS_START_MJD'])+int(dd[kk]['OBSERVATIONS']['OBSERVATION_1']['OBS_START_MPM'])/(1e3*24*3600)
-            mjd_stop = mjd_start + int(dd[kk]['OBSERVATIONS']['OBSERVATION_1']['OBS_DUR'])/(1e3*24*3600)
-            mjd_now = time.Time.now().mjd
-            if mjd_now > mjd_start and mjd_now < mjd_stop:
-                sessionname = kk
-                session = dd[sessionname]['SESSION']
-                observation = dd[sessionname]['OBSERVATIONS']['OBSERVATION_1']  # TODO: verify only one gets submitted
+            for kkobs in dd[kk]['OBSERVATIONS'].keys():
+                mjd_start = int(dd[kk]['OBSERVATIONS'][kkobs]['OBS_START_MJD'])+int(dd[kk]['OBSERVATIONS'][kkobs]['OBS_START_MPM'])/(1e3*24*3600)
+                mjd_stop = mjd_start + int(dd[kk]['OBSERVATIONS'][kkobs]['OBS_DUR'])/(1e3*24*3600)
+                mjd_now = time.Time.now().mjd
+                if mjd_now > mjd_start and mjd_now < mjd_stop:
+                    sessionname = kk
+                    session = dd[sessionname]['SESSION']
+                    observation = dd[sessionname]['OBSERVATIONS'][kkobs]  # TODO: verify only one gets submitted
 
     # Top level attributes
     ## Observer and Project Info.

--- a/ovro_data_recorder/lwahdf.py
+++ b/ovro_data_recorder/lwahdf.py
@@ -12,9 +12,16 @@ from dsautils import dsa_store
 __all__ = ['create_hdf5', 'set_frequencies', 'set_time',
            'set_polarization_products']
 
-lwahdf_logger = logging.getLogger('__main__')
-ls = dsa_store.DsaStore()
+
 HDF5_CHUNK_SIZE_MB = 32
+
+
+# Logging instance
+lwahdf_logger = logging.getLogger('__main__')
+
+
+# DsaStore instance
+ls = dsa_store.DsaStore()
 
 
 def create_hdf5(filename, beam, overwrite=False):

--- a/ovro_data_recorder/lwahdf.py
+++ b/ovro_data_recorder/lwahdf.py
@@ -50,16 +50,20 @@ def create_hdf5(filename, beam, overwrite=False):
     sessionname = None
     session = {}
     observation = {}
-    for kk, vv in dd.items():
+    mjd_now = time.Time.now().mjd
+    for kk, _ in dd.items():
         if dd[kk]['SESSION']['SESSION_DRX_BEAM'] == str(beam):
             for kkobs in dd[kk]['OBSERVATIONS'].keys():
                 mjd_start = int(dd[kk]['OBSERVATIONS'][kkobs]['OBS_START_MJD'])+int(dd[kk]['OBSERVATIONS'][kkobs]['OBS_START_MPM'])/(1e3*24*3600)
                 mjd_stop = mjd_start + int(dd[kk]['OBSERVATIONS'][kkobs]['OBS_DUR'])/(1e3*24*3600)
-                mjd_now = time.Time.now().mjd
-                if mjd_now > mjd_start and mjd_now < mjd_stop:
+                if mjd_now >= mjd_start and mjd_now < mjd_stop:
                     sessionname = kk
                     session = dd[sessionname]['SESSION']
-                    observation = dd[sessionname]['OBSERVATIONS'][kkobs]  # TODO: verify only one gets submitted
+                    observation = dd[sessionname]['OBSERVATIONS'][kkobs]
+                    break
+            else:
+                continue
+            break
 
     # Top level attributes
     ## Observer and Project Info.

--- a/ovro_data_recorder/lwahdf.py
+++ b/ovro_data_recorder/lwahdf.py
@@ -96,7 +96,6 @@ def create_hdf5(filename, beam, overwrite=False):
     obs.attrs['Dec'] = float(observation.get('OBS_DEC', -99.0))
     obs.attrs['Dec_Units'] = 'degrees'
     obs.attrs['Epoch'] = 2000.0
-    obs.attrs['Epoch'] = 2000.0
     obs.attrs['TrackingMode'] = observation.get('OBS_MODE', 'Unknown')
     
     ## Observation info


### PR DESCRIPTION
As discussed in https://github.com/ovro-lwa/lwa-issues/issues/564 (and noted in the first PR), we did not properly treat observations not named "OBSERVATION_1". This change will iterate over all obs in a session and try to match the time range to the file being written.
Not yet tested.