### PR TITLE
Minor update: port number for streaming

### DIFF
--- a/docs/source/pbeam.rst
+++ b/docs/source/pbeam.rst
@@ -202,8 +202,8 @@ The ``AvgStreamingOp`` provides real-time data streaming capabilities for extern
  and then streams data via ZMQ (ZeroMQ) PUB socket for efficient real-time transmission
 
 **Streaming Configuration:**
- * **Default Address:** 127.0.0.1 (localhost)
- * **Default Port:** 9798
+ * **Default Address:** 127.0.0.1 (localhost) (defined by the ``--streaming-address`` command line argument)
+ * **Default Port:** 30000 (defined by the ``--streaming-port`` command line argument), should follow a convention of dr[#] using port number 30000 + #, where # is the power beam number.
  * **Default Interval:** 0.25 seconds (configurable)
  * **Protocol:** ZMQ PUB/SUB pattern for one-to-many communication
 

--- a/scripts/dr_beam.py
+++ b/scripts/dr_beam.py
@@ -700,6 +700,8 @@ def main(argv):
                         help='quota for the recording directory, 0 disables the quota')
     parser.add_argument('-f', '--fork', action='store_true',
                         help='fork and run in the background')
+    parser.add_argument('-s', '--streaming-port', type=int, default=30000,
+                        help='streaming port number')
 
 
     args = parser.parse_args()
@@ -779,7 +781,8 @@ def main(argv):
                             threads=ops, gulp_time=args.gulp_size*24*(2*NCHAN/CLOCK)))  # Ugh, hard coded
                                 
     ops.append(AvgStreamingOp(log, capture_ring,
-                               ntime_gulp=args.gulp_size, core=cores.pop(0)))
+                               ntime_gulp=args.gulp_size, core=cores.pop(0),
+                               stream_port=args.streaming_port))
     
     ops.append(PowerBeamCommandProcessor(log, mcs_id, args.record_directory, QUEUE))
     


### PR DESCRIPTION
I just realized that there are two beams at same node, meaning can't use same port to stream data.

Newer versions use `--streaming-port` of `dr_beam.py` to detemine the port number.

I suggest using the 3000[_] as port (for example 'dr2' use 30002), so it's easy to look for the correct stream to subscribe.